### PR TITLE
Update poliziano-orfeo.xml

### DIFF
--- a/tei/poliziano-orfeo.xml
+++ b/tei/poliziano-orfeo.xml
@@ -263,8 +263,8 @@
           <lg>
             <l>ch'i' so che la mia nympha el canto agogna.</l>
           </lg>
-          <stage>Canzona.</stage>
           <lg>
+            <stage>Canzona.</stage>
             <l>Udite, selve, mie dolce parole,</l>
             <l>poi che la nympha mia udir non vuole.</l>
           </lg>


### PR DESCRIPTION
Issue at line 266: Having the stage direction `<stage> Canzona. </stage>` ("song") between a `</lg>` and `<lg>` apparently creates an artificial `who="canzona"` tag to which the following lines of speech of are attributed (see [spoken text by character](https://dracor.org/api/corpora/ita/play/poliziano-orfeo/spoken-text-by-character.json) and the [TEI-XML file](https://dracor.org/api/corpora/ita/play/poliziano-orfeo/tei)). To correct this error, I propose to move the stage direction one line down, inside the `<lg>` element.